### PR TITLE
Fix example that passes with order(:name) implementation

### DIFF
--- a/spec/models/person_spec.rb
+++ b/spec/models/person_spec.rb
@@ -11,13 +11,15 @@ describe Person do
         create(:location, name: "location2")
       ]
       locations.each do |location|
-        create(:person, location: location, name: "at-#{location.name}")
+        create(:person, location: location)
       end
 
       result = Person.order_by_location_name
 
-      expect(result.map(&:name)).
-        to eq(%w(at-location1 at-location2 at-location3))
+      result.each_with_index do |person, index|
+        expect(person.location.name).
+          to eq Location.order(:name).map(&:name).at(index)
+      end
     end
   end
 


### PR DESCRIPTION
Thanks for making Upcase free! 🤩

Since the first test is plopping the location name into a person's name, then you can just order by the person's name to get the desired affect.
```ruby
def self.order_by_location_name
  order(:name)
end
```
The test seems to be indirectly grouping people by location through `person.name`. I think either assigning different names to the people objects or changing the expectation clause would rule out the `order(:name)` solution. I would opt for the latter so that the expectation aligns with the "it" description.

This example still passes with the featured solution, but does not pass with `order(:name)`.
